### PR TITLE
fix: handle bot errors properly

### DIFF
--- a/backend/src/bot/handle-error.ts
+++ b/backend/src/bot/handle-error.ts
@@ -1,0 +1,18 @@
+import type { ErrorHandler } from 'grammy'
+import { GrammyError, HttpError } from 'grammy'
+import type { Ctx } from './context'
+
+/**
+ * @see https://grammy.dev/guide/errors
+ */
+export const handleError: ErrorHandler<Ctx> = (error) => {
+  let msg
+  if (error instanceof GrammyError) {
+    msg = 'Bot API request failed'
+  } else if (error instanceof HttpError) {
+    msg = 'network error'
+  } else {
+    msg = 'error in middleware'
+  }
+  error.ctx.logger.error({ msg, error })
+}

--- a/backend/src/bot/index.ts
+++ b/backend/src/bot/index.ts
@@ -2,6 +2,7 @@ import { Bot } from 'grammy'
 import plugins from './plugins'
 import handlers from './handlers'
 import type { Ctx } from './context'
+import { handleError } from './handle-error'
 import type { Logger } from '~/utils/logging'
 import type { Domain } from '~/domain'
 import type { Config } from '~/config'
@@ -18,6 +19,8 @@ export function createBot({
   domain: Domain
 }): Bot<Ctx> {
   const bot = new Bot<Ctx>(token)
+
+  bot.catch(handleError)
 
   plugins.logging.install(bot, { logger })
   plugins.floodControl.install(bot)


### PR DESCRIPTION
### Description of changes

Added error handler with `bot.catch`.

Closes #2.