### PR TITLE
feat: make days keyboard calendar like

### DIFF
--- a/backend/src/bot/handlers/views/trainings_days-list.tsx
+++ b/backend/src/bot/handlers/views/trainings_days-list.tsx
@@ -4,44 +4,52 @@ import type { View } from '.'
 import views from '.'
 import type { Ctx } from '~/bot/context'
 import { TIMEZONE, TRAININGS_DAYS_LIST_COUNT } from '~/constants'
-import { getDateDayInTimezone, getDayBoundaries } from '~/utils/dates'
+import { Day, getSpanningWeeks } from '~/utils/dates'
+import { NoopButton } from '~/bot/plugins/noop-button'
 
 const VIEW_ID = 'trainings/days-list'
 
 const BackButton = makeButton({ id: `${VIEW_ID}:back` })
-const DayButton = makeButton<{ date: Date }>({
+const DayButton = makeButton<{ day: Day }>({
   id: `${VIEW_ID}:day`,
-  encode: ({ date }) => date.toISOString(),
-  decode: data => ({ date: new Date(data) }),
+  encode: ({ day }) => day.toString(),
+  decode: data => ({ day: Day.fromString(data) }),
 })
 
 export default {
   render: async (ctx) => {
-    const now = new Date()
+    // Make keyboard like this:
+    //
+    // Mo Tu We Th Fr Sa Su
+    // -- -- 01 02 03 04 05
+    // 06 07 08 -- -- -- --
+
+    const today = Day.fromDate(new Date(), TIMEZONE)
+    const lastDay = today.shift(TRAININGS_DAYS_LIST_COUNT - 1)
+    const weeksDays = getSpanningWeeks(today, lastDay)
+
+    const weekdaysRow = (['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const)
+      .map(weekday => (
+        <NoopButton>{ctx.t['Weekday.TwoLetters'](weekday)}</NoopButton>
+      ))
+    const daysRows = weeksDays.map(weekDays => (
+      <>
+        {weekDays.map(day => (
+          day === null
+            ? <NoopButton />
+            : <DayButton day={day}>{day.date.toString()}</DayButton>
+        ))}
+        <br />
+      </>
+    ))
 
     return (
       <>
         {ctx.t['Views.TrainingsDaysList.Message']}
         <keyboard>
-          {Array(TRAININGS_DAYS_LIST_COUNT).fill(null).map((_, i) => {
-            const actualDate = new Date(now.getTime())
-            actualDate.setDate(now.getDate() + i)
-
-            const day = getDateDayInTimezone(actualDate, TIMEZONE)
-            const [timezoneDate, __] = getDayBoundaries({
-              ...day,
-              timezone: TIMEZONE,
-            })
-
-            return (
-              <>
-                <DayButton date={actualDate}>
-                  {ctx.t['Views.TrainingsDaysList.Buttons.Day'](timezoneDate)}
-                </DayButton>
-                <br />
-              </>
-            )
-          })}
+          {weekdaysRow}
+          <br />
+          {daysRows}
           <BackButton>{ctx.t['Buttons.Back']}</BackButton>
         </keyboard>
       </>
@@ -55,7 +63,7 @@ export default {
       .use(async (ctx) => {
         await ctx
           .edit(ctx.chat!.id, ctx.callbackQuery.message!.message_id)
-          .to(await views.trainingsDayTrainings.render(ctx, { date: ctx.payload.date }))
+          .to(await views.trainingsDayTrainings.render(ctx, { day: ctx.payload.day }))
         ctx.answerCallbackQuery()
       })
 

--- a/backend/src/bot/index.ts
+++ b/backend/src/bot/index.ts
@@ -27,6 +27,7 @@ export function createBot({
   plugins.messageSending.install(bot)
   plugins.domain.install(bot, { domain, config })
   plugins.translations.install(bot)
+  plugins.noopButton.install(bot)
 
   bot.use(handlers)
 

--- a/backend/src/bot/plugins/index.ts
+++ b/backend/src/bot/plugins/index.ts
@@ -4,6 +4,7 @@ import * as floodControl from './flood-control'
 import * as messageSending from './message-sending'
 import * as domain from './domain'
 import * as translations from './translations'
+import * as noopButton from './noop-button'
 
 // eslint-disable-next-line ts/ban-types
 export type InstallFn<F = {}, O = undefined> =
@@ -17,4 +18,5 @@ export default {
   messageSending,
   domain,
   translations,
+  noopButton,
 }

--- a/backend/src/bot/plugins/noop-button.tsx
+++ b/backend/src/bot/plugins/noop-button.tsx
@@ -1,0 +1,15 @@
+import type { TgxElement } from '@telegum/tgx'
+import type { InstallFn } from '.'
+
+const CALLBACK_QUERY_DATA = 'noop'
+
+export function NoopButton({ children }: { children?: string }): TgxElement {
+  return <button data={CALLBACK_QUERY_DATA}>{children || ' '}</button>
+}
+
+export const install: InstallFn = (bot) => {
+  bot.callbackQuery(CALLBACK_QUERY_DATA, async (ctx, next) => {
+    await ctx.answerCallbackQuery({ cache_time: 300 })
+    return next()
+  })
+}

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -1,2 +1,2 @@
 export const TIMEZONE = 'Europe/Moscow'
-export const TRAININGS_DAYS_LIST_COUNT = 7
+export const TRAININGS_DAYS_LIST_COUNT = 8

--- a/backend/src/translations/_en.tsx
+++ b/backend/src/translations/_en.tsx
@@ -1,5 +1,6 @@
 import { TIMEZONE } from '~/constants'
 import type { TrainingDetailed } from '~/services/sport/types'
+import type { Weekday } from '~/utils/dates'
 import { clockTime } from '~/utils/dates'
 import { tgxFromHtml } from '~/utils/tgx-from-html'
 
@@ -13,6 +14,18 @@ function dateLong(date: Date): string {
 }
 
 export default {
+  'Weekday.TwoLetters': (weekday: Weekday) => {
+    switch (weekday) {
+      case 'mon': return 'Mo'
+      case 'tue': return 'Tu'
+      case 'wed': return 'We'
+      case 'thu': return 'Th'
+      case 'fri': return 'Fr'
+      case 'sat': return 'Sa'
+      case 'sun': return 'Su'
+    }
+  },
+
   'Buttons.Back': '← Back',
 
   'HowGoodAmI.Thinking': 'Hmm... Let me think 🤔',
@@ -46,13 +59,6 @@ export default {
   'Views.LanguageSettings.Message': 'Which flag do you like more?',
 
   'Views.TrainingsDaysList.Message': 'Choose the date:',
-  'Views.TrainingsDaysList.Buttons.Day': (date: Date) => {
-    const day = date.toLocaleDateString('en-US', { weekday: 'long', timeZone: TIMEZONE })
-    const month = date.toLocaleDateString('en-US', { month: 'long', timeZone: TIMEZONE })
-    const dayOfMonth = date.getDate()
-
-    return `${day}, ${month} ${dayOfMonth}`
-  },
 
   'Views.DayTrainings.Message': 'Choose the class:',
 

--- a/backend/src/utils/dates.test.ts
+++ b/backend/src/utils/dates.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import {
-  getDateDayInTimezone,
-  getDayBoundaries,
-  getTimezoneOffset,
-} from './dates'
+import type { Weekday } from './dates'
+import { Day, getTimezoneOffset } from './dates'
 
 describe('getTimezoneOffset', () => {
   it('returns correct offset for Europe/Moscow', () => {
@@ -14,45 +11,102 @@ describe('getTimezoneOffset', () => {
   })
 })
 
-describe('getDateDayInTimezone', () => {
-  it('returns correct date for 17/03/2024 in Moscow timezone', () => {
-    expect(
-      getDateDayInTimezone(new Date('2024-03-17T22:03:00Z'), 'Europe/Moscow'),
-    ).toEqual({ year: 2024, month: 3, day: 18 })
+describe('day', () => {
+  it('creates correct day from string', () => {
+    let day = Day.fromString('2024-03-17')
+    expect(day.year).toBe(2024)
+    expect(day.month).toBe(3)
+    expect(day.date).toBe(17)
+
+    day = Day.fromString('2024-02-29')
+    expect(day.year).toBe(2024)
+    expect(day.month).toBe(2)
+    expect(day.date).toBe(29)
   })
 
-  it('returns correct date for 17/03/2024 in UTC timezone', () => {
-    expect(
-      getDateDayInTimezone(new Date('2024-03-17T22:03:00Z'), 'UTC'),
-    ).toEqual({ year: 2024, month: 3, day: 17 })
-  })
-})
-
-describe('getDayBoundaries', () => {
-  it('returns correct boundaries for 17/03/2024 in Moscow timezone', () => {
-    expect(
-      getDayBoundaries({
-        year: 2024,
-        month: 3,
-        day: 17,
-        timezone: 'Europe/Moscow',
-      }),
-    ).toEqual([
-      new Date('2024-03-16T21:00:00Z'),
-      new Date('2024-03-17T21:00:00Z'),
-    ])
+  it('converts to string correctly', () => {
+    expect(Day.fromString('2024-03-17').toString()).toBe('2024-03-17')
+    expect(Day.fromString('2024-02-29').toString()).toBe('2024-02-29')
   })
 
-  it('returns correct boundaries for 17/03/2024 in UTC timezone', () => {
-    expect(
-      getDayBoundaries({
-        year: 2024,
-        month: 3,
-        day: 17,
-      }),
-    ).toEqual([
-      new Date('2024-03-17T00:00:00Z'),
-      new Date('2024-03-18T00:00:00Z'),
-    ])
+  it('creates correct day from date and timezone', () => {
+    const date = new Date('2024-03-17T22:03:00Z')
+    let day = Day.fromDate(date, 'UTC')
+    expect(day.year).toBe(2024)
+    expect(day.month).toBe(3)
+    expect(day.date).toBe(17)
+
+    day = Day.fromDate(date, 'Europe/Moscow')
+    expect(day.year).toBe(2024)
+    expect(day.month).toBe(3)
+    expect(day.date).toBe(18)
+  })
+
+  it('converts to date with timezone correctly', () => {
+    let date = Day.fromString('2024-03-17').asDate('UTC')
+    expect(date.toISOString()).toBe('2024-03-17T00:00:00.000Z')
+
+    date = Day.fromString('2024-03-17').asDate('Europe/Moscow')
+    expect(date.toISOString()).toBe('2024-03-17T03:00:00.000Z')
+  })
+
+  it('returns correct weekday', () => {
+    const testcases: [string, Weekday][] = [
+      ['2024-01-01', 'mon'],
+      ['2024-01-02', 'tue'],
+      ['2024-01-03', 'wed'],
+      ['2024-01-04', 'thu'],
+      ['2024-01-05', 'fri'],
+      ['2024-01-06', 'sat'],
+      ['2024-01-07', 'sun'],
+
+      ['2024-04-01', 'mon'],
+      ['2024-04-02', 'tue'],
+      ['2024-04-03', 'wed'],
+      ['2024-04-04', 'thu'],
+      ['2024-04-05', 'fri'],
+      ['2024-04-06', 'sat'],
+      ['2024-04-07', 'sun'],
+
+      ['2024-12-30', 'mon'],
+      ['2024-12-31', 'tue'],
+      ['2025-01-01', 'wed'],
+      ['2025-01-02', 'thu'],
+      ['2025-01-03', 'fri'],
+      ['2025-01-04', 'sat'],
+      ['2025-01-05', 'sun'],
+    ]
+    for (const [dateStr, weekday] of testcases) {
+      expect(Day.fromString(dateStr).weekday).toBe(weekday)
+    }
+  })
+
+  it('shifts correctly', () => {
+    const testcases: [string, number, string][] = [
+      ['2024-01-01', -3, '2023-12-29'],
+      ['2024-01-01', -2, '2023-12-30'],
+      ['2024-01-01', -1, '2023-12-31'],
+      ['2024-01-01', 0, '2024-01-01'],
+      ['2024-01-01', 1, '2024-01-02'],
+      ['2024-01-01', 2, '2024-01-03'],
+      ['2024-01-01', 3, '2024-01-04'],
+    ]
+    for (const [dateStr, shift, expectedStr] of testcases) {
+      expect(Day.fromString(dateStr).shift(shift).toString()).toBe(expectedStr)
+    }
+  })
+
+  it('returns correct boundaries', () => {
+    const testcases: [string, string, [string, string]][] = [
+      ['2024-03-17', 'UTC', ['2024-03-17T00:00:00.000Z', '2024-03-18T00:00:00.000Z']],
+      ['2024-02-29', 'UTC', ['2024-02-29T00:00:00.000Z', '2024-03-01T00:00:00.000Z']],
+      ['2024-03-17', 'Europe/Moscow', ['2024-03-16T21:00:00.000Z', '2024-03-17T21:00:00.000Z']],
+      ['2024-02-29', 'Europe/Moscow', ['2024-02-28T21:00:00.000Z', '2024-02-29T21:00:00.000Z']],
+    ]
+    for (const [dateStr, timezone, [startStr, endStr]] of testcases) {
+      const [start, end] = Day.fromString(dateStr).boundaries(timezone)
+      expect(start.toISOString()).toBe(startStr)
+      expect(end.toISOString()).toBe(endStr)
+    }
   })
 })


### PR DESCRIPTION
### Description of changes

- Limit of the days in days list keyboard increased from 7 to 8.
- `dates` utility methods refactored, `Day` class created, related tests updated.
- Keyboard of days list now renders as calendar.