### PR TITLE
Use en dashes in time periods

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024—PRESENT one-zero-eight
+Copyright (c) 2024–PRESENT one-zero-eight
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/backend/src/bot/handlers/views/trainings.tsx
+++ b/backend/src/bot/handlers/views/trainings.tsx
@@ -135,7 +135,7 @@ export default makeView<Props>({
                       renderDetails={false}
                       backTab={tab}
                     >
-                      {`${statusEmoji} ${timeStart}—${timeEnd}`}
+                      {`${statusEmoji} ${timeStart}–${timeEnd}`}
                     </ToggleCheckInButton>
                     <TrainingDetailsButton trainingId={training.id} fromTab={tab}>
                       {`${isFavorite ? '⭐️ ' : ''}${training.title}`}

--- a/backend/src/translations/_en.tsx
+++ b/backend/src/translations/_en.tsx
@@ -23,7 +23,7 @@ function dateAndTimeShort(
   const monthShort = startsAt.toLocaleDateString('en-US', { month: 'short', timeZone: TIMEZONE })
   const dayOfMonth = startsAt.toLocaleDateString('en-US', { day: 'numeric', timeZone: TIMEZONE })
 
-  return `${weekDayShort} ${monthShort} ${dayOfMonth}, ${clockTime(startsAt, TIMEZONE)}—${clockTime(endsAt, TIMEZONE)}`
+  return `${weekDayShort} ${monthShort} ${dayOfMonth}, ${clockTime(startsAt, TIMEZONE)}–${clockTime(endsAt, TIMEZONE)}`
 }
 
 function beautifulSemesterTitle(raw: string): string {
@@ -180,7 +180,7 @@ export default {
       {dateLong(startsAt)}
       <br />
       <b>Time: </b>
-      {`${clockTime(startsAt, TIMEZONE)}—${clockTime(endsAt, TIMEZONE)}`}
+      {`${clockTime(startsAt, TIMEZONE)}–${clockTime(endsAt, TIMEZONE)}`}
       <br />
       <b>Accreditted: </b>
       {accredited ? 'Yes' : 'No'}

--- a/backend/src/translations/_ru.tsx
+++ b/backend/src/translations/_ru.tsx
@@ -33,7 +33,7 @@ function dateAndTimeShort(
 
   const weekDayCapitalized = weekDayShort.charAt(0).toUpperCase() + weekDayShort.slice(1)
 
-  return `${weekDayCapitalized}, ${dayOfMonth}.${month}.${year} в ${clockTime(startsAt, TIMEZONE)}—${clockTime(endsAt, TIMEZONE)}`
+  return `${weekDayCapitalized}, ${dayOfMonth}.${month}.${year} в ${clockTime(startsAt, TIMEZONE)}–${clockTime(endsAt, TIMEZONE)}`
 }
 
 function beautifulSemesterTitle(raw: string): string {
@@ -193,7 +193,7 @@ export default {
       {dateLong(startsAt)}
       <br />
       <b>Время: </b>
-      {`${clockTime(startsAt, TIMEZONE)}—${clockTime(endsAt, TIMEZONE)}`}
+      {`${clockTime(startsAt, TIMEZONE)}–${clockTime(endsAt, TIMEZONE)}`}
       <br />
       <b>Аккредитовано: </b>
       {accredited ? 'да' : 'нет'}


### PR DESCRIPTION
According to typographic conventions, time periods should be separated with an en dash (–) rather than an em dash (—).

This small PR fixes this issue wherever possible.

(I'm not sure, though, whether I've chosen a correct commit type, but it doesn't seem to be a `docs` or `chore` change, and the actual UI is affected.)