### PR TITLE
fix: show actual load in the timeslot description

### DIFF
--- a/backend/src/translations/_en.tsx
+++ b/backend/src/translations/_en.tsx
@@ -188,7 +188,7 @@ export default {
       {`${clockTime(startsAt, TIMEZONE)}–${clockTime(endsAt, TIMEZONE)}`}
       <br />
       <b>Available places: </b>
-      {`${load}/${capacity}`}
+      {`${capacity - load}/${capacity}`}
       <br />
       <b>Place: </b>
       {`${location}`}

--- a/backend/src/translations/_ru.tsx
+++ b/backend/src/translations/_ru.tsx
@@ -201,7 +201,7 @@ export default {
       {`${clockTime(startsAt, TIMEZONE)}–${clockTime(endsAt, TIMEZONE)}`}
       <br />
       <b>Доступные места: </b>
-      {`${load}/${capacity}`}
+      {`${capacity - load}/${capacity}`}
       <br />
       <b>Место: </b>
       {`${location}`}


### PR DESCRIPTION
### Description of changes
Just a fix of a text representation
Change {load} to {capacity - load} both in English and in Russian
Closes #51 